### PR TITLE
[fix] NoneType object has no attribute startswith

### DIFF
--- a/foundation/erpnext_foundation/doctype/service_provider/service_provider.py
+++ b/foundation/erpnext_foundation/doctype/service_provider/service_provider.py
@@ -20,5 +20,5 @@ class ServiceProvider(WebsiteGenerator):
 			title='All Service Providers in {0}'.format(self.country))]
 		if self.member:
 			context.membership_type = frappe.get_value('Member', self.member, 'membership_type')
-		if not context.website.startswith('http'):
+		if context.website and not context.website.startswith('http'):
 			context.website = 'http://' + context.website


### PR DESCRIPTION
NoneType object has no attribute startswith, if website has not defined in the service provider's profile

Issue
![screen shot 2017-05-01 at 7 36 45 pm](https://cloud.githubusercontent.com/assets/8780500/25581448/8ae393d2-2ea5-11e7-94c1-e795477301db.png)
