### PR TITLE
[minor] fixed TypeError: 'NoneType' object has no attribute '__getitem__'

### DIFF
--- a/foundation/www/service-providers.html
+++ b/foundation/www/service-providers.html
@@ -34,8 +34,8 @@
 {% macro show_member(s) %}
 	<div class='col-sm-4' style='height: 130px; padding-bottom: 30px'>
 		<p>
-			<a class='bold' href="/{{ s.route }}">{{ s.title[:25] }}</a><br>
-			{{ s.introduction[:100] }}
+			<a class='bold' href="/{{ s.route }}">{{ s.title and s.title[:25] }}</a><br>
+			{{ s.introduction and s.introduction[:100] }}
 		</p>
 	</div>
 {% endmacro %}


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/website/render.py", line 39, in render
    data = render_page_by_language(path)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/website/render.py", line 134, in render_page_by_language
    return render_page(path)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/website/render.py", line 150, in render_page
    return build(path)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/website/render.py", line 157, in build
    return build_page(path)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/website/render.py", line 176, in build_page
    html = frappe.render_template(context.source, context)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/utils/jinja.py", line 70, in render_template
    return get_jenv().from_string(template).render(context)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 38, in top-level template code
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/./templates/web.html", line 1, in top-level template code
    {% extends base_template_path %}
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe_theme/frappe_theme/./templates/base.html", line 1, in top-level template code
    {% extends "frappe/templates/base.html" %}
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/./templates/base.html", line 69, in top-level template code
    {% block content %}{% endblock %}
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/./templates/web.html", line 47, in block "content"
    {%- block page_content -%}{%- endblock -%}
  File "<template>", line 76, in block "page_content"
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/jinja2/runtime.py", line 553, in _invoke
    rv = self._func(*arguments)
  File "<template>", line 38, in template
TypeError: 'NoneType' object has no attribute '__getitem__'
```