### PR TITLE
fix media image sizes on chrome and correct typo on homepage and footer. closes #128 and closes #123

### DIFF
--- a/foundation/public/css/erpnext-org-theme.css
+++ b/foundation/public/css/erpnext-org-theme.css
@@ -962,11 +962,19 @@ img.blog-cover-image,
   }
 }
 .media-left {
-  width: 10%;
-  margin-right: 2.5rem;
+  margin-bottom: 1.5rem;
+}
+@media screen and (min-width: 500px) {
+  .media-left {
+    margin-right: 2.5rem;
+    margin-bottom: 0;
+  }
 }
 .media-heading {
   margin-top: 0;
+}
+.media-object {
+  width: 6.5rem;
 }
 .with-border {
   border-radius: 0.25em;

--- a/foundation/public/less/erpnext-org-theme.less
+++ b/foundation/public/less/erpnext-org-theme.less
@@ -936,12 +936,20 @@ img.blog-cover-image,
 }
 
 .media-left {
-	width: 10%;
-	margin-right: 2.5rem;
+	margin-bottom: 1.5rem;
+
+	@media screen and (min-width: @screen-palm) {
+		margin-right: 2.5rem;
+		margin-bottom: 0;
+	}
 }
 
 .media-heading {
 	margin-top: 0;
+}
+
+.media-object {
+	width: 6.5rem;
 }
 
 .with-border {

--- a/foundation/templates/includes/footer/footer.html
+++ b/foundation/templates/includes/footer/footer.html
@@ -3,7 +3,7 @@
  <div class="container">
 	<div class="four-column left-aligned clearfix">
 		<div class="columns">
-			<h3 class="footer-title text-white">Domains</h3>
+			<h3 class="footer-title text-white">Industries</h3>
 			<ul class="list-unstyled footer-list">
 				<li>
 					<a class="secondary-link" href="/docs/user/manual/en/manufacturing">Manufacturing</a>

--- a/foundation/www/index.html
+++ b/foundation/www/index.html
@@ -19,7 +19,7 @@
                 </a>
             </li>
             <li class="list-items">
-				<a class="primary-links grid-boxes" href="/docs/user/manual/en/manufacturing">
+				<a class="primary-links grid-boxes" href="/docs/user/manual/en/projects">
 					<img class="grid-images" src="/assets/foundation/img/services.png" alt="ERP software for Services"><span>Services</span>
 				</a>
             </li>


### PR DESCRIPTION
This PR corrects the image sizes of the media boxes on chrome and changes the name title "Domains" to "Industries" to keep consistency. Also fixes the link to service industry which was earlier going to manufacturing.