### PR TITLE
[assets][fix] add bootstrapjs resource in base.html (now?)

### DIFF
--- a/foundation/templates/base.html
+++ b/foundation/templates/base.html
@@ -51,6 +51,8 @@
             src="/assets/frappe/js/lib/jquery/jquery.min.js"></script>
         <script type="text/javascript"
             src="/assets/js/frappe-web.min.js"></script>
+        <script type="text/javascript"
+            src="/assets/frappe/js/lib/bootstrap.min.js"></script>
         {% endblock %}
         {%- if js_globals is defined %}
         <script>


### PR DESCRIPTION
Fixing all `dropdown()` and `tooltip()` issues.

As `base.html` is overridden than that of frappe: https://github.com/frappe/frappe/blob/develop/frappe/templates/base.html#L85 

I feel I'm missing something. How did we not have this yet?