### PR TITLE
Membership History Display,  Fixes #178

### DIFF
--- a/foundation/__init__.py
+++ b/foundation/__init__.py
@@ -8,10 +8,21 @@ import frappe
 
 def get_last_membership():
 	'''Returns last membership if exists'''
-	last_membership = frappe.get_all('Membership', 'name,to_date,membership_type',
-		dict(member=frappe.session.user, paid=1), order_by='to_date desc', limit=1)
+	member_id = frappe.db.get_value("Member", {'email': frappe.session.user}, "name")
+	if member_id:
+		last_membership = frappe.get_all('Membership', 'name,to_date,membership_type',
+			dict(member=member_id, paid=1), order_by='to_date desc', limit=1)
 
 	return last_membership and last_membership[0]
+
+def get_all_memberships_of_one_member():
+	'''Returns all memberships'''
+	member_id = frappe.db.get_value("Member", {'email': frappe.session.user}, "name")
+	if member_id:
+		all_memberships = frappe.get_all('Membership', 'name,from_date,to_date,membership_type,amount,currency',
+			dict(member=member_id, paid=1), order_by='to_date desc')
+
+	return all_memberships
 
 def is_member():
 	'''Returns true if the user is still a member'''

--- a/foundation/www/members/details.html
+++ b/foundation/www/members/details.html
@@ -18,17 +18,46 @@
 {% elif frappe.utils.getdate(last_membership.to_date) < frappe.utils.getdate(frappe.utils.nowdate()) %}
 	<p>Your Membership has expired, Click the button below to start a new membership</p>
 	<p><a href="/members/setup_payment" class='btn btn-primary'>Renew</a></p>
-	<p><a href="/memberships" class='text-muted'>View Membership History</a></p>
 
 {% elif frappe.utils.getdate(frappe.utils.add_days(last_membership.to_date, -30)) < frappe.utils.getdate(frappe.utils.nowdate())%}
 	<p>Your Membership is due to expire soon. Click on the button below to renew</p>
 	<p><a href="/members/setup_payment" class='btn btn-primary'>Renew</a></p>
-	<p><a href="/memberships" class='text-muted'>View Membership History</a></p>
 
 {% else %}
 	<p>Welcome back <b>{{ last_membership.membership_type }} Member!</b></p>
 	<p>Your membership is due to expire on {{ frappe.format_date(last_membership.to_date) }}.
-	<p><a href="/memberships" class='text-muted'>View Membership History</a></p>
+
+{% endif %}
+
+{% if last_membership %}
+
+	<br>
+	<div class="table-responsive">
+    <table class="table table-bordered table-hover">
+      <thead>
+        <tr class="active">
+          <th style="width: 200px">Membership Number</th>
+          <th style="width: 150px">Membership Type</th>
+          <th style="width: 150px">From</th>
+          <th style="width: 150px">To</th>
+          <th style="width: 100px">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+				{% for membership in all_memberships %}
+
+          <tr>
+            <td>{{ membership.name }}</td>
+            <td>{{ membership.membership_type }}</td>
+            <td>{{ frappe.format_date(membership.from_date) }}</td>
+            <td>{{ frappe.format_date(membership.to_date) }}</td>
+            <td>{{ frappe.utils.fmt_money(membership.amount,currency=frappe.db.get_value("Currency",membership.currency,"symbol")) }}</td>
+          </tr>
+					{% endfor %}
+      </tbody>
+    </table>
+</div>
+
 {% endif %}
 
 {% endif %}

--- a/foundation/www/members/details.py
+++ b/foundation/www/members/details.py
@@ -7,3 +7,4 @@ def get_context(context):
 	if frappe.session.user != 'Guest':
 		context.show_sidebar = True
 		context.last_membership = foundation.get_last_membership()
+		context.all_memberships = foundation.get_all_memberships_of_one_member()


### PR DESCRIPTION
This PR fixes two issues.

Issue 1:

Currently if you login as a member and click on "Membership" link on side bar, it will show as below.

![screen shot 2018-05-25 at 3 56 46 pm](https://user-images.githubusercontent.com/11595602/40540131-b00d42cc-6034-11e8-8232-989e6e83d8dc.png)

There is no need for another "View History Button", changes in this PR will remove the button and display membership history in its place.

![screen shot 2018-05-25 at 4 02 55 pm](https://user-images.githubusercontent.com/11595602/40540289-3b5221cc-6035-11e8-86d3-e7ee53242609.png)

Issue 2:

Initially member DocType's `name` was email id of the member and it has been changed to naming series based  string recently.

![screen shot 2018-05-25 at 3 56 04 pm](https://user-images.githubusercontent.com/11595602/40540584-47002d6a-6036-11e8-8d50-a6ee281e72d6.png)

Existing code fetched latest membership record assuming the 'name' field is same as email id.

Modified code to fetch actual `name`(ex : MEM-0004) based on the email id, then fetched the membership record.


