### PR TITLE
Home > Membership Plans, and not on Signup option

### DIFF
--- a/foundation/www/index.html
+++ b/foundation/www/index.html
@@ -116,7 +116,7 @@
 		<div class="text-center">
 			<h1 class="header-1">ERPNext Foundation</h1>
 			<p class="intro-copy text-medium">ERPNext Foundation is a community of ERPNext users, developers and service providers. The goal of the ERPNext Foundation is to provide a platform for the ERPNext Community to come together, join hands and build assets to help build and enhance ERPNext around the world.</p>
-			<a href="/members/details" class="button button-secondary">Become a Member</a>
+			<a href="/members" class="button button-secondary">Become a Member</a>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
On clicking Become a Member, user should be directed to the list of Membership plans, and not signup option directly.