### PR TITLE
Fix Video embed link

### DIFF
--- a/foundation/www/docs/user/manual/en/customize-erpnext/articles/making-custom-reports-in-erpnext.md
+++ b/foundation/www/docs/user/manual/en/customize-erpnext/articles/making-custom-reports-in-erpnext.md
@@ -8,8 +8,8 @@ There are three kind of reports in ERPNext.
 Report Builder is an in-built report customization tool in ERPNext. This allows you to define specific fields of the form which shall be added in the report. Also you can set required filters, sorting and give preferred name to report.
 
 <div class="embed-container">
-    <iframe src="https://www.youtube.com/watch?v=TxJGUNarcQs?rel=0" frameborder="0" allowfullscreen>
-    </iframe>
+    <iframe src="<iframe src="https://www.youtube.com/embed/TxJGUNarcQs?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    </iframe> 
 </div>
 
 ### 2. Query Report


### PR DESCRIPTION
Fixing the video embed link for Custom Report Builder.

Earlier it was just a blank space having the container.

Now: 

![image](https://user-images.githubusercontent.com/33246109/42218252-912cdfdc-7ee5-11e8-8082-6f84d00e28c8.png)

Prev:

![image](https://user-images.githubusercontent.com/33246109/42218266-9dfa152c-7ee5-11e8-81ff-1733bda4705c.png)

