### PR TITLE
Fix title of link to german manual

### DIFF
--- a/foundation/www/docs/_sidebar.json
+++ b/foundation/www/docs/_sidebar.json
@@ -9,7 +9,7 @@
  },
  {
   "route": "/docs/user/manual/de",
-  "title": "Manual (Deutsche)"
+  "title": "Handbuch (Deutsch)"
  },
  {
   "route": "/docs/user/videos/learn",


### PR DESCRIPTION
Old, incorrect: "Manual (Deutsche)"
New, correct: "Handbuch (Deutsch)"