### PR TITLE
Corrected Video Link for Student Group

### DIFF
--- a/foundation/www/docs/user/manual/en/education/student/student-group.md
+++ b/foundation/www/docs/user/manual/en/education/student/student-group.md
@@ -29,7 +29,7 @@ You can also update the **Email Group** for the Student Group. Click on Update E
     <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
     </style>
     <div class='embed-container'>       
-        <iframe src='https://www.youtube.com/embed/QILiHiTD3uc'
+        <iframe src='https://www.youtube.com/embed/5K_smeeE1Q4'
         frameborder='0' allowfullscreen>
         </iframe>
     </div> 


### PR DESCRIPTION
The video link in the Student Group's documentation was wrong hence replaced it with the correct tutorial link.