### PR TITLE
Replace "the bench" with bench

### DIFF
--- a/foundation/www/get-started.html
+++ b/foundation/www/get-started.html
@@ -19,7 +19,7 @@
 
 <section class="section-padding">
 	<div class='container text-center'>
-		<h4>Self Install on Linux using the Bench</h4>
+		<h4>Self Install on Linux using Bench</h4>
 		<p class="lead mb-4">Bench is a command-line tool to install and manage ERPNext.</p>
 		<a target="_blank" class='btn btn-dark' href="https://github.com/frappe/bench">Read the instructions on GitHub</a>
 	</div>


### PR DESCRIPTION
Since "Bench" is a proper noun, I propose to remove the article "the" preceding bench in line 22. Justification: http://web.mit.edu/course/21/21.guide/art-pnou.htm