### PR TITLE
Update period-closing-voucher.md

### DIFF
--- a/foundation/www/docs/user/manual/en/accounts/tools/period-closing-voucher.md
+++ b/foundation/www/docs/user/manual/en/accounts/tools/period-closing-voucher.md
@@ -24,7 +24,7 @@ In ERPNext after making all the special entries via Journal Entry for the curren
 
 <img class="screenshot" alt="Period Closing Voucher" src="{{docs_base_url}}/assets/img/accounts/period-closing-voucher.png">
 
-This voucher will transfer Profit or Loss (availed from P&L statment) to Closing Account Head. You should select a liability account like Reserves and Surplus, or Capital Fund account as Closing Account.
+This voucher will transfer Profit or Loss (availed from P&L statment) to Closing Account Head. You should select a liability account like Reserves and Surplus, or Any Revenue Reserve account or into Owners Capital account as Closing Account.
 
 The Period Closing Voucher will make accounting entries (GL Entry) making all your Income and Expense Accounts zero and transferring Profit/Loss balance to the Closing Account.
 


### PR DESCRIPTION
Capital Fund account is a misnomer for Revenue reserve group. Profit & Loss balance is in the nature of Revenue reserve and it can not be merged into Capital reserve account. Another word for the reserve is also "Fund". Hence making these changes would make it accurate in the accounting sense.