### PR TITLE
Highlighted the Tax Accounts selection

### DIFF
--- a/foundation/www/docs/user/manual/en/accounts/item-wise-taxation.md
+++ b/foundation/www/docs/user/manual/en/accounts/item-wise-taxation.md
@@ -15,7 +15,9 @@ Here is the example of Item on which 5% GST is applied only.
 
 <img class="screenshot" alt="Opening Account" src="{{docs_base_url}}/assets/img/accounts/item-wise-tax.png">
 
-For the item which is exempted from GST totally, mention 0% as tax rate in the Item master. Note that the Tax accounts set in Item Tax table (with changed tax rates) in Item master are part of the _default_ Sales / Purhcase Tax Template.
+For the item which is exempted from GST totally, mention 0% as tax rate in the Item master. 
+
+> Note: For Item Tax to work, you need to ensure that the Tax accounts set in Item Tax table (with changed tax rates) in Item master are part of the _default_ Sales / Purhcase Tax Template.
 
 <img class="screenshot" alt="Opening Account" src="{{docs_base_url}}/assets/img/accounts/exempted-item.png">
 


### PR DESCRIPTION
Without this, item tax overriding doesn't work - the earlier note wasn't quite noticeable.