### PR TITLE
fix: Documentation Link

### DIFF
--- a/foundation/templates/includes/footer/footer.html
+++ b/foundation/templates/includes/footer/footer.html
@@ -98,7 +98,7 @@
 					<li class="mb-2">
 						<a class="text-muted" href="https://erpnext.com/version-12">Version 12</a>
 					<li class="mb-2">
-						<a class="text-muted" href="/https://erpnext.com/docs/user/manual">Manual</a>
+						<a class="text-muted" href="https://erpnext.com/docs/">Manual</a>
 					</li>
 					<li class="mb-2">
 						<a class="text-muted" href="https://www.youtube.com/c/erpnext" target="_blank" >Video Tutorials</a>


### PR DESCRIPTION
The footer redirects to the correct link of ERPNext Documentation