### PR TITLE
chore: Remove broken link

### DIFF
--- a/foundation/templates/includes/footer/footer.html
+++ b/foundation/templates/includes/footer/footer.html
@@ -75,9 +75,6 @@
 					<a class="text-muted" href="/erpnext-jobs">ERPNext Jobs</a>
 				</li>
 				<li class="mb-2">
-					<a class="text-muted"  href="https://gitter.im/frappe/erpnext" target="_blank" >Chat (Gitter)</a>
-				</li>
-				<li class="mb-2">
 					<a class="text-muted" href="https://github.com/frappe/erpnext" target="_blank" >GitHub</a>
 				</li>
 				<li class="mb-2">


### PR DESCRIPTION
Removed link for Gitter (Chat) since it is not supported anymore